### PR TITLE
Add Search model for saving search metadata

### DIFF
--- a/backend/src/controllers/ProjectController.ts
+++ b/backend/src/controllers/ProjectController.ts
@@ -190,6 +190,8 @@ class ProjectController {
         techMatchesProjects: params.techMatches.map((p) => p.id),
         matchedTechs: params.matchedTechs.map((t) => t._id),
         mergedCount: params.mergedCount,
+        totalCount: params.totalCount,
+        timeElapsedMs: params.timeElapsedMs,
         user: isValidObjectId(params.user) ? params.user : null,
       });
       logger.info("Search saved " + search._id, {

--- a/backend/src/controllers/ProjectController.ts
+++ b/backend/src/controllers/ProjectController.ts
@@ -1,5 +1,5 @@
 import logger from "../logger";
-import { ClientSession, Document, Model, ObjectId } from "mongoose";
+import { ClientSession, Document, isValidObjectId, Model, ObjectId } from "mongoose";
 import { MongoError } from "mongodb";
 import _, { merge } from "lodash";
 import { IMember } from "../models/Member";
@@ -19,6 +19,7 @@ import {
   mergeResults,
 } from "./projects/searchHelpers";
 import { TechDoc } from "./TechController";
+import { ISearch } from "../models/Search";
 
 export interface ProjectUpdateParams {
   name?: string;
@@ -50,6 +51,18 @@ export type ProjectSearchResultItem = {
   matchType: MatchType;
 };
 
+interface SaveSearchParams {
+  query: string;
+  nameMatches: ProjectSearchResultItem[];
+  descriptionMatches: ProjectSearchResultItem[];
+  techMatches: ProjectSearchResultItem[];
+  matchedTechs: TechDoc[];
+  mergedCount: number;
+  totalCount: number;
+  timeElapsedMs: number;
+  user?: ObjectId;
+}
+
 class ProjectController {
   constructor(
     private projectModel: Model<IProject>,
@@ -57,6 +70,7 @@ class ProjectController {
     private userModel: Model<IUser>,
     private memberModel: Model<IMember>,
     private techModel: Model<ITech>,
+    private searchModel: Model<ISearch>,
     private createSession: () => Promise<ClientSession>
   ) {}
 
@@ -81,7 +95,7 @@ class ProjectController {
     return project;
   }
 
-  async searchProjects(search: string): Promise<ProjectSearchResultItem[]> {
+  async searchProjects(search: string, user?: ObjectId): Promise<ProjectSearchResultItem[]> {
     const start = Date.now();
 
     const nameMatches: ProjectSearchResultItem[] =
@@ -131,6 +145,18 @@ class ProjectController {
     const merged = mergeResults(total);
     const timeElapsedMs = Date.now() - start;
 
+    this.saveSearch({
+      query: search,
+      nameMatches,
+      descriptionMatches,
+      techMatches,
+      matchedTechs: techs,
+      mergedCount: merged.length,
+      totalCount: total.length,
+      timeElapsedMs,
+      user,
+    });
+
     logger.info("[project_search_stat]", {
       search,
       timeElapsedMs,
@@ -143,6 +169,38 @@ class ProjectController {
     });
 
     return merged;
+  }
+
+  // Tracks searches, so this method should be as lightweight as possible.
+  saveSearch(params: SaveSearchParams) {
+    // Run this asynchronously so that it does not block the request.
+    setTimeout(() => this.saveSearchSafe(params));
+  }
+
+  /**
+   * saveSearchSafe suppresses exceptions by catching, logging, and moving on
+   * so that it does not fail the caller.
+   */
+  async saveSearchSafe(params: SaveSearchParams) {
+    try {
+      const search = await this.searchModel.create({
+        query: params.query,
+        nameMatchesProjects: params.nameMatches.map((p) => p.id),
+        descriptionMatchesProjects: params.descriptionMatches.map((p) => p.id),
+        techMatchesProjects: params.techMatches.map((p) => p.id),
+        matchedTechs: params.matchedTechs.map((t) => t._id),
+        mergedCount: params.mergedCount,
+        user: isValidObjectId(params.user) ? params.user : null,
+      });
+      logger.info("Search saved " + search._id, {
+        searchId: search._id,
+      });
+    } catch (err: any) {
+      logger.error("Failed to save search!!", {
+        errorMessage: err.message,
+        params,
+      })
+    }
   }
 
   async lookup(pageSize: number): Promise<ProjectDoc[]> {

--- a/backend/src/models/Search.ts
+++ b/backend/src/models/Search.ts
@@ -1,0 +1,75 @@
+import { model, ObjectId, Schema } from "mongoose";
+import { IProject } from "./Project";
+import { ITech } from "./Tech";
+import { IUser } from "./User";
+
+export interface ISearch {
+  query: string;
+  nameMatchesProjects: IProject[] | ObjectId[];
+  descriptionMatchesProjects: IProject[] | ObjectId[];
+  techMatchesProjects: IProject[] | ObjectId[];
+  matchedTechs: ITech[] | ObjectId[];
+  mergedCount: number;
+  totalCount: number;
+  timeElapsedMs: number;
+  user: IUser | ObjectId | null;
+  createdAt: Date;
+}
+
+/**
+ * None of the fields are indexed to improve insert speed.
+ * Future optimization can be done by batching inserts and
+ * writing in bulk.
+ */
+const SearchSchema = new Schema<ISearch>(
+  {
+    query: {
+      type: Schema.Types.String,
+    },
+    nameMatchesProjects: {
+      type: [Schema.Types.ObjectId],
+      ref: "project",
+    },
+    descriptionMatchesProjects: {
+      type: [Schema.Types.ObjectId],
+      ref: "project",
+    },
+    techMatchesProjects: {
+      type: [Schema.Types.ObjectId],
+      ref: "project",
+    },
+    matchedTechs: {
+      type: [Schema.Types.ObjectId],
+      ref: "tech",
+    },
+    mergedCount: {
+      type: Schema.Types.Number,
+    },
+    totalCount: {
+      type: Schema.Types.Number,
+    },
+    timeElapsedMs: {
+      type: Schema.Types.Number,
+    },
+    user: {
+      type: Schema.Types.ObjectId,
+      ref: "user",
+    },
+    // Updates are not supported, so we only need to track createdAt.
+    createdAt: {
+      type: Schema.Types.Date,
+      default: () => new Date(),
+    },
+  }
+);
+
+SearchSchema.set("toJSON", {
+  transform: (_, ret, __) => {
+    ret.id = ret._id;
+    delete ret._id;
+    delete ret.__v;
+    return ret;
+  },
+});
+
+export default model<ISearch>("search", SearchSchema);

--- a/backend/src/routes/projectRouter.ts
+++ b/backend/src/routes/projectRouter.ts
@@ -9,6 +9,7 @@ import Project from "../models/Project";
 
 import User from "../models/User";
 import Tech from "../models/Tech";
+import Search from "../models/Search";
 
 /* dependencies */
 const projectController = new ProjectController(
@@ -16,6 +17,7 @@ const projectController = new ProjectController(
   User,
   Member,
   Tech,
+  Search,
   () => startSession()
 );
 
@@ -145,7 +147,8 @@ projects.get("/v1/project_search", async (req, res, next) => {
   if (req.query["search"]) {
     try {
       const project = await projectController.searchProjects(
-        req.query["search"].toString()
+        req.query["search"].toString(),
+        req.user?.id
       );
 
       res.json(project);

--- a/docs/DESIGN.md
+++ b/docs/DESIGN.md
@@ -12,6 +12,9 @@ vice versa (projects can be associated with multiple users).
 
 Applications represent a User's request to be added as a Member to a Project.
 
+Search is an insert-only collection we don't plan to update the items of.
+It saves the metadata of project searches for downstream processing.
+
 ```
 User {
   id: ObjectId
@@ -29,6 +32,18 @@ Project {
   description: string // short description
   techs: ObjectId[] // ref to Tech
   settingOpenRoles: string[] // default ["developer", "designer"]
+}
+
+Search {
+  query: string;
+  nameMatchesProjects: ObjectId[]; // ref to Project
+  descriptionMatchesProjects: ObjectId[]; // ref to Project
+  techMatchesProjects: ObjectId[]; // ref to Project
+  matchedTechs: ObjectId[]; // ref to Tech
+  mergedCount: number;
+  totalCount: number;
+  timeElapsedMs: number;
+  user: ObjectId | null; // ref to User, the logged-in user making the search
 }
 
 Member {


### PR DESCRIPTION
# Changes

- Add Search model for saving metadata of searches

# Testing

- Run app
- Go to `/projects/search` and enter a search term
- Check application logs and check that `Search saved...` comes after `[project_search_stat]` (it means that the setTimeout for asynchronous saving is working)

## Example log
```
[0] info: [project_search_stat] {"descriptionMatchesLength":2,"merged":4,"nameMatchesLength":1,"search":"typescript","techMatchesLength":3,"techsFound":1,"timeElapsedMs":154,"total":6}
[0] info: Search saved 622d523c8d23d2b117afd5f7 {"searchId":"622d523c8d23d2b117afd5f7"}
```

Closes #85 