### PR TITLE
Fix illustration width on mobile

### DIFF
--- a/frontend/src/components/front_page/FrontPage.tsx
+++ b/frontend/src/components/front_page/FrontPage.tsx
@@ -5,7 +5,7 @@ const FrontPage = () => {
   return (
     <>
       <div className="bg-white pt-4 md:pt-12">
-        <div className="mx-3 _my-4 md:mx-8 _md:my-12">
+        <div className="mx-3 md:mx-8">
           <Hero />
         </div>
       </div>

--- a/frontend/src/components/front_page/Hero.tsx
+++ b/frontend/src/components/front_page/Hero.tsx
@@ -17,7 +17,7 @@ const Hero = () => {
         </Link>
       </div>
       <div className="relative top-28 md:top-[-8rem] md:right-0 md:text-right text-center">
-        <ConnectionIllustration className="inline-block h-80" />
+        <ConnectionIllustration className="inline-block max-h-80 w-full md:w-auto" />
       </div>
     </div>
   );


### PR DESCRIPTION
# Changes

- Fit illustration to width on sizes smaller than `md:` and use max height to limit size instead

## Before
<img width="201" alt="Screen Shot 2022-03-14 at 5 39 52 PM" src="https://user-images.githubusercontent.com/8432061/158283743-77d0f0b8-151b-4a7b-bfbf-7642cefa131e.png">

## After
<img width="201" alt="Screen Shot 2022-03-14 at 5 39 35 PM" src="https://user-images.githubusercontent.com/8432061/158283747-08c724a8-c0e3-4ac5-978b-94bcdd40d677.png">

