### PR TITLE
Add backfillStarrers script

### DIFF
--- a/backend/scripts/backfillStarrers.ts
+++ b/backend/scripts/backfillStarrers.ts
@@ -1,0 +1,28 @@
+import mongoose, { ConnectOptions } from "mongoose";
+import Project from "../src/models/Project";
+
+// Updates projects with missing `starrers` field with
+// an empty array.
+//
+// Usage:
+// From backend directory,
+// run `yarn script scripts/backfillStarrers.ts`
+(async () => {
+  mongoose.connect((process.env && process.env["MONGODB_URI"]) || "", {
+    useNewUrlParser: true,
+    useUnifiedTopology: true,
+  } as ConnectOptions);
+
+  const result = await Project.updateMany(
+    {
+      starrers: { $exists: false },
+    },
+    {
+      starrers: [],
+    }
+  );
+
+  console.log(`Updated ${result.modifiedCount} projects with starrers array.`);
+
+  process.exit(0);
+})();


### PR DESCRIPTION
# Changes

- Adds `backfillStarrers.ts` script for backfill the `starrers` field in Project

Note: This should no longer be needed but I'm adding it as a reference. We currently fill in the starrers field now when the Project is first created.

Running this script now should result in an output like:
```
Updated 0 projects with starrers array.
```