### PR TITLE
Add Procfile to work around heroku buildpack regression

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn start


### PR DESCRIPTION
According to this fly.io platform post, we can explicitly specify how the buildpack runtime should start the server by defining a Procfile https://github.com/chingu-voyages/v37-bears-team-14/pull/new/fix/buildpack-regression