### PR TITLE
Pin node version to 16.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,5 +14,8 @@
   "devDependencies": {
     "concurrently": "^7.0.0",
     "prettier": "^2.5.1"
+  },
+  "engines": {
+    "node": "16.x"
   }
 }


### PR DESCRIPTION
# Changes

- nodejs version 16 needed to be explicitly specified, even with name/version fields in the top-level package.json. the buildpack changes on fly.io were using nodejs 17.x, which mongoose was incompatible with

console output from deploy test success:
```
[Sat Mar 26 11:32:20] ../chingu-voyages/v37-bears-team-14 (main) $ flyctl deploy
...
[Checking Node.js version]
Detected Node.js version range: >=16.0.0 <17.0.0-0
Resolved Node.js version: 16.14.0

[Installing Node.js distribution]
Downloading Node.js 16.14.0
Extracting Node.js 16.14.0
Installing Node.js 16.14.0
...
image: registry.fly.io/v37-bears-team-14:deployment-1648319544
image size: 1.4 GB
==> Creating release
--> release v77 created

--> You can detach the terminal anytime without stopping the deployment
==> Monitoring deployment

 1 desired, 1 placed, 1 healthy, 0 unhealthy
--> v77 deployed successfully
```