### PR TITLE
Set increase soft_limit from 20 to 100

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -25,8 +25,8 @@ processes = []
   script_checks = []
 
   [services.concurrency]
-    hard_limit = 25
-    soft_limit = 20
+    hard_limit = 150
+    soft_limit = 100
     type = "connections"
 
   [[services.ports]]


### PR DESCRIPTION
# Changes

- fly config soft_limit from 20 to 100
- fly config hard_limit from 25 to 150

Reference: https://community.fly.io/t/connection-count-limits/99/2

It would appear as if our server can handle more connections, potentially allowing us to use fewer server nodes at a time to handle the same number of client connections.